### PR TITLE
fix: constant variable typo in google secret

### DIFF
--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -22,5 +22,5 @@ export const NEXT_PUBLIC_ADMIN_EMAIL = process.env
 export const NEXT_PUBLIC_GOOGLE_ID = process.env
   .NEXT_PUBLIC_GOOGLE_ID as string;
 export const NEXT_PUBLIC_GOOGLE_SECRET = process.env
-  .NEEXT_PUBLIC_GOOGLE_SECRET as string;
+  .NEXT_PUBLIC_GOOGLE_SECRET as string;
 export const EMAIL_NAME = process.env.EMAIL_NAME as string;

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -7,6 +7,8 @@ import {
   NEXT_PUBLIC_GOOGLE_SECRET,
   NEXTAUTH_SECRET,
 } from "@/lib/utils/constants";
+import { prisma } from "@/lib/utils/prisma";
+import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import type { Awaitable, NextAuthOptions, User } from "next-auth";
 import NextAuth from "next-auth/next";
 import GithubProvider, { GithubProfile } from "next-auth/providers/github";
@@ -62,6 +64,7 @@ export const options: NextAuthOptions = {
       return session;
     },
   },
+  adapter: PrismaAdapter(prisma),
 };
 
 export default NextAuth(options);


### PR DESCRIPTION
fix: constant variable typo in google secret
chore: add prisma adapter for next auth